### PR TITLE
Normalize Maven POMs and fix dependency issues

### DIFF
--- a/thoth-ai-ms/pom.xml
+++ b/thoth-ai-ms/pom.xml
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <artifactId>thoth-parent</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-ai-ms</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-
     <name>thoth-ai-ms</name>
     <description>thoth-ai</description>
-
     <modules>
         <module>thoth-ai-entity</module>
         <module>thoth-ai-service</module>
@@ -29,8 +23,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.2</version>
         </dependency>
-
-
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-dependencies</artifactId>
@@ -43,7 +35,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
     <developers>
         <developer>
@@ -52,5 +43,4 @@
             <organization>prometheus</organization>
         </developer>
     </developers>
-
 </project>

--- a/thoth-ai-ms/thoth-ai-entity/pom.xml
+++ b/thoth-ai-ms/thoth-ai-entity/pom.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-ai-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-ai-entity</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <name>thoth-ai-entity</name>
     <!--引入auth entity-->
     <dependencies>

--- a/thoth-ai-ms/thoth-ai-service/pom.xml
+++ b/thoth-ai-ms/thoth-ai-service/pom.xml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-ai-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-ai-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <name>thoth-ai-service</name>
-
     <dependencies>
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-ai-entity</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-feign</artifactId>
         </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
             <groupId>org.json</groupId>
@@ -37,12 +30,7 @@
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-robot-entity</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.prometheus</groupId>
-            <artifactId>thoth-robot-entity</artifactId>
-        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/thoth-ai-ms/thoth-ai-web/pom.xml
+++ b/thoth-ai-ms/thoth-ai-web/pom.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-ai-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>thoth-ai-web</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-ai-web</name>
-
     <properties>
         <start-class>com.prometheus.thoth.AIMsApplication</start-class>
-
         <thoth-ai-ms.version>0.0.1-SNAPSHOT</thoth-ai-ms.version>
-        <mysql.version></mysql.version>
+        <mysql.version>5.1.41</mysql.version>
         <thoth-ai.version>0.0.1-SNAPSHOT</thoth-ai.version>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -30,7 +23,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.41</version>
+            <version>${mysql.version}</version>
         </dependency>
         <dependency>
             <groupId>com.prometheus</groupId>
@@ -47,13 +40,11 @@
             <artifactId>thoth-ai-service</artifactId>
             <version>${thoth-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-fastdfs</artifactId>
             <version>${thoth-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -64,7 +55,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
@@ -83,5 +73,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/thoth-config-server/pom.xml
+++ b/thoth-config-server/pom.xml
@@ -1,28 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-parent</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>thoth-config-server</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-config-server</name>
     <url>http://maven.apache.org</url>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-server</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-eureka</artifactId>

--- a/thoth-registry-server/pom.xml
+++ b/thoth-registry-server/pom.xml
@@ -1,18 +1,15 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-parent</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>thoth-registry-server</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-registry-server</name>
     <url>http://maven.apache.org</url>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/thoth-robot-ms/pom.xml
+++ b/thoth-robot-ms/pom.xml
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <artifactId>thoth-parent</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-robot-ms</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-
     <name>thoth-robot-ms</name>
     <description>thoth-robot</description>
-
     <modules>
         <module>thoth-robot-entity</module>
         <module>thoth-robot-service</module>
@@ -36,7 +30,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
     <developers>
         <developer>
@@ -45,5 +38,4 @@
             <organization>prometheus</organization>
         </developer>
     </developers>
-
 </project>

--- a/thoth-robot-ms/thoth-robot-common/pom.xml
+++ b/thoth-robot-ms/thoth-robot-common/pom.xml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-robot-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>thoth-robot-common</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <name>thoth-robot-common</name>
-    <dependencies>
-    </dependencies>
-
+    <dependencies/>
 </project>

--- a/thoth-robot-ms/thoth-robot-entity/pom.xml
+++ b/thoth-robot-ms/thoth-robot-entity/pom.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-robot-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-robot-entity</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <name>thoth-robot-entity</name>
     <!--引入auth entity-->
     <dependencies>

--- a/thoth-robot-ms/thoth-robot-service/pom.xml
+++ b/thoth-robot-ms/thoth-robot-service/pom.xml
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-robot-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-robot-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <name>thoth-robot-service</name>
-
     <dependencies>
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-robot-entity</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-feign</artifactId>
@@ -31,10 +25,7 @@
             <artifactId>thoth-robot-common</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
-
-
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/thoth-robot-ms/thoth-robot-web/pom.xml
+++ b/thoth-robot-ms/thoth-robot-web/pom.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>thoth-robot-ms</artifactId>
         <groupId>com.prometheus</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>thoth-robot-web</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-robot-web</name>
-
     <properties>
         <start-class>com.prometheus.thoth.RobotApplication</start-class>
-
         <thoth-robot-ms.version>0.0.1-SNAPSHOT</thoth-robot-ms.version>
         <mysql.version>5.1.41</mysql.version>
         <thoth-robot.version>0.0.1-SNAPSHOT</thoth-robot.version>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -30,6 +23,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
         </dependency>
         <dependency>
             <groupId>com.prometheus</groupId>
@@ -51,13 +45,11 @@
             <artifactId>thoth-robot-common</artifactId>
             <version>${thoth-robot.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-fastdfs</artifactId>
             <version>${thoth-robot.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -68,7 +60,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
@@ -87,5 +78,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/thoth/pom.xml
+++ b/thoth/pom.xml
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-
-	<groupId>com.prometheus</groupId>
-	<artifactId>thoth</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<modules>
-		<module>thoth-parent</module>
-		<module>thoth-common</module>
-		<module>thoth-dependencies</module>
-		<module>thoth-data-es</module>
-		<module>thoth-data-hbase</module>
-		<module>thoth-data-kafka</module>
-		<module>thoth-fastdfs</module>
-		<module>thoth-mongo</module>
-		<module>thoth-redis</module>
-		<module>thoth-test</module>
-	</modules>
-	<packaging>pom</packaging>
-
-	<name>thoth</name>
-	<description>Prometheus</description>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.prometheus</groupId>
+    <artifactId>thoth</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <modules>
+        <module>thoth-parent</module>
+        <module>thoth-common</module>
+        <module>thoth-dependencies</module>
+        <module>thoth-data-es</module>
+        <module>thoth-data-hbase</module>
+        <module>thoth-data-kafka</module>
+        <module>thoth-fastdfs</module>
+        <module>thoth-mongo</module>
+        <module>thoth-redis</module>
+        <module>thoth-test</module>
+    </modules>
+    <packaging>pom</packaging>
+    <name>thoth</name>
+    <description>Prometheus</description>
 </project>

--- a/thoth/thoth-common/pom.xml
+++ b/thoth/thoth-common/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,12 +7,9 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-common</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-common</name>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -40,19 +35,15 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
         </dependency>
-
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -61,5 +52,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/thoth/thoth-data-es/pom.xml
+++ b/thoth/thoth-data-es/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,23 +7,18 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-data-es</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-data-es</name>
-
     <dependencies>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
             <version>${elasticsearch.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/thoth/thoth-data-hbase/pom.xml
+++ b/thoth/thoth-data-hbase/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,12 +7,9 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-data-hbase</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-data-hbase</name>
-
     <dependencies>
         <!-- hbase -->
         <dependency>
@@ -68,7 +63,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>

--- a/thoth/thoth-data-kafka/pom.xml
+++ b/thoth/thoth-data-kafka/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,29 +7,24 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-data-kafka</artifactId>
     <packaging>pom</packaging>
     <version>0.0.1-SNAPSHOT</version>
     <name>thoth-data-kafka</name>
-
     <modules>
         <module>thoth-data-kafka-producer</module>
         <module>thoth-data-kafka-consumer</module>
     </modules>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>0.10.0.1</version>
         </dependency>
-
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-common</artifactId>

--- a/thoth/thoth-data-kafka/thoth-data-kafka-consumer/pom.xml
+++ b/thoth/thoth-data-kafka/thoth-data-kafka-consumer/pom.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
         <artifactId>thoth-data-kafka</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-data-kafka-consumer</artifactId>
     <packaging>jar</packaging>
-
-<name>thoth-data-kafka-consumer</name>
-<dependencies>
-    <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>1.3.2</version>
-        <scope>provided</scope>
-    </dependency>
-</dependencies>
-
+    <name>thoth-data-kafka-consumer</name>
+    <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/thoth/thoth-data-kafka/thoth-data-kafka-producer/pom.xml
+++ b/thoth/thoth-data-kafka/thoth-data-kafka-producer/pom.xml
@@ -1,23 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
         <artifactId>thoth-data-kafka</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-data-kafka-producer</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-data-kafka-producer</name>
-
-
     <dependencies>
-
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -29,5 +21,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-
 </project>

--- a/thoth/thoth-dependencies/pom.xml
+++ b/thoth/thoth-dependencies/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,14 +7,10 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-dependencies</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-dependencies</name>
-
     <dependencies>
-
         <!-- SPRING BOOT begin -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -28,17 +22,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -49,22 +40,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
@@ -78,7 +65,6 @@
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis-spring</artifactId>
@@ -88,35 +74,28 @@
             <groupId>org.mybatis.spring.boot</groupId>
             <artifactId>mybatis-spring-boot-starter</artifactId>
         </dependency>
-
         <!-- pagehelper -->
         <dependency>
             <groupId>com.github.pagehelper</groupId>
             <artifactId>pagehelper-spring-boot-starter</artifactId>
         </dependency>
-
         <!-- jdbc driver -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
-
         <!-- jackson2 -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <optional>true</optional>
         </dependency>
-
         <!-- LOGGING begin -->
-
         <!-- LOGGING end -->
-
         <!-- GENERAL UTILS begin -->
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -142,25 +121,21 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
         </dependency>
-
         <!-- pojo -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-
         <!-- joda time -->
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
-
         <!-- fasterxml uuid -->
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
@@ -168,12 +143,10 @@
             <optional>true</optional>
         </dependency>
         <!-- OTHER TOOLS end -->
-
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-
         <!--swagger-->
         <dependency>
             <groupId>io.springfox</groupId>
@@ -184,5 +157,4 @@
             <artifactId>springfox-swagger-ui</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/thoth/thoth-fastdfs/pom.xml
+++ b/thoth/thoth-fastdfs/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,12 +7,9 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-fastdfs</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-fastdfs</name>
-
     <dependencies>
         <dependency>
             <groupId>com.github.tobato</groupId>
@@ -31,12 +26,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.prometheus</groupId>
             <artifactId>thoth-common</artifactId>

--- a/thoth/thoth-mongo/pom.xml
+++ b/thoth/thoth-mongo/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,12 +7,9 @@
         <relativePath>../thoth-parent/pom.xml</relativePath>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-mongo</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-mongo</name>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -25,7 +20,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
@@ -44,6 +38,5 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/thoth/thoth-parent/pom.xml
+++ b/thoth/thoth-parent/pom.xml
@@ -1,28 +1,22 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <groupId>com.prometheus</groupId>
     <artifactId>thoth-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-
     <name>thoth-parent</name>
     <url>http://maven.apache.org</url>
-
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.5.8.RELEASE</version>
     </parent>
-
-    <modelVersion>4.0.0</modelVersion>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <spring-cloud.version>Dalston.SR4</spring-cloud.version>
-
         <fastjson.version>1.2.31</fastjson.version>
         <disruptor.version>3.3.7</disruptor.version>
         <commons-lang3.version>3.5</commons-lang3.version>
@@ -35,10 +29,8 @@
         <pagehelper.version>5.0.0</pagehelper.version>
         <pagehelper-spring-boot-starter.version>1.1.0</pagehelper-spring-boot-starter.version>
         <mapper-spring-boot-starter.version>1.0.0</mapper-spring-boot-starter.version>
-
         <mysql.version>5.1.41</mysql.version>
         <springfox-swagger.version>2.6.1</springfox-swagger.version>
-
         <elasticsearch.version>5.5.2</elasticsearch.version>
         <fastdfs-client.version>1.25.4-RELEASE</fastdfs-client.version>
         <kafka-clients.version>0.10.0.1</kafka-clients.version>
@@ -48,44 +40,36 @@
         <jwt.version>2.2.0</jwt.version>
         <oval.version>1.85</oval.version>
         <dbunit.version>2.5.3</dbunit.version>
-        <commons-lang3.version>3.5</commons-lang3.version>
         <jjwt.version>0.6.0</jjwt.version>
         <simplecaptcha.version>1.2.2</simplecaptcha.version>
         <spring-kafka.version>1.1.3.RELEASE</spring-kafka.version>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -95,19 +79,16 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -128,13 +109,11 @@
                 <artifactId>joda-time</artifactId>
                 <version>${joda-time.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
@@ -157,33 +136,28 @@
                 <artifactId>mybatis</artifactId>
                 <version>${mybatis.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.mybatis</groupId>
                 <artifactId>mybatis-spring</artifactId>
                 <version>${mybatis-spring.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.mybatis.spring.boot</groupId>
                 <artifactId>mybatis-spring-boot-starter</artifactId>
                 <version>${mybatis-spring-boot-starter.version}</version>
             </dependency>
-
             <!-- mapper -->
             <dependency>
                 <groupId>tk.mybatis</groupId>
                 <artifactId>mapper-spring-boot-starter</artifactId>
                 <version>${mapper-spring-boot-starter.version}</version>
             </dependency>
-
             <!-- mybatis page plugin -->
             <dependency>
                 <groupId>com.github.pagehelper</groupId>
                 <artifactId>pagehelper</artifactId>
                 <version>${pagehelper.version}</version>
             </dependency>
-
             <!-- springfox-swagger -->
             <dependency>
                 <groupId>io.springfox</groupId>
@@ -195,7 +169,6 @@
                 <artifactId>springfox-swagger-ui</artifactId>
                 <version>${springfox-swagger.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.github.tobato</groupId>
                 <artifactId>fastdfs-client</artifactId>
@@ -211,16 +184,9 @@
                 <artifactId>thoth-clazz-entity</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.prometheus</groupId>
                 <artifactId>thoth-clazz-service</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.prometheus</groupId>
-                <artifactId>thoth-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -241,12 +207,6 @@
             <dependency>
                 <groupId>com.prometheus</groupId>
                 <artifactId>thoth-data-entity</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.prometheus</groupId>
-                <artifactId>thoth-data-kafka</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -299,8 +259,6 @@
                 <artifactId>thoth-question-service</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-
             <dependency>
                 <groupId>org.springframework.kafka</groupId>
                 <artifactId>spring-kafka</artifactId>
@@ -311,7 +269,6 @@
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka-clients.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-client</artifactId>
@@ -364,16 +321,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-swagger2</artifactId>
-                <version>${springfox-swagger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-swagger-ui</artifactId>
-                <version>${springfox-swagger.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.uuid</groupId>
                 <artifactId>java-uuid-generator</artifactId>
                 <version>${java-uuid-generator.version}</version>
@@ -387,21 +334,6 @@
                 <groupId>com.github.pagehelper</groupId>
                 <artifactId>pagehelper-spring-boot-starter</artifactId>
                 <version>${pagehelper-spring-boot-starter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mybatis.spring.boot</groupId>
-                <artifactId>mybatis-spring-boot-starter</artifactId>
-                <version>${mybatis-spring-boot-starter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mybatis</groupId>
-                <artifactId>mybatis-spring</artifactId>
-                <version>${mybatis-spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mybatis</groupId>
-                <artifactId>mybatis</artifactId>
-                <version>${mybatis.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
@@ -418,7 +350,6 @@
                 <artifactId>jjwt</artifactId>
                 <version>${jjwt.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>net.sf.oval</groupId>
                 <artifactId>oval</artifactId>
@@ -430,7 +361,6 @@
                 <scope>test</scope>
                 <version>${dbunit.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.auth0</groupId>
                 <artifactId>java-jwt</artifactId>
@@ -438,10 +368,8 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>
-
         <plugins>
             <!--用于编译Maven项目的Java源代码-->
             <plugin>
@@ -479,7 +407,6 @@
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
         </plugins>
-
         <pluginManagement>
             <plugins>
                 <!--用于编译Maven项目的Java源代码-->
@@ -593,7 +520,6 @@
                         </configurationFile>
                     </configuration>
                 </plugin>
-
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin-ext</artifactId>
@@ -606,7 +532,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
@@ -620,7 +545,6 @@
                     <version>2.8.2</version>
                 </plugin>
             </plugins>
-
         </pluginManagement>
     </build>
 </project>

--- a/thoth/thoth-redis/pom.xml
+++ b/thoth/thoth-redis/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,12 +7,9 @@
         <relativePath>../thoth-parent/pom.xml</relativePath>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-
     <artifactId>thoth-redis</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-redis</name>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -35,7 +30,5 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/thoth/thoth-test/pom.xml
+++ b/thoth/thoth-test/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.prometheus</groupId>
@@ -9,20 +7,15 @@
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../thoth-parent/pom.xml</relativePath>
     </parent>
-
     <artifactId>thoth-test</artifactId>
     <packaging>jar</packaging>
-
     <name>thoth-test</name>
-
     <dependencies>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <!-- TEST begin -->
         <!-- junit -->
         <dependency>
@@ -30,7 +23,6 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <!-- spring boot test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -39,5 +31,4 @@
         </dependency>
         <!-- TEST end -->
     </dependencies>
-
 </project>


### PR DESCRIPTION
## Summary
- format every pom.xml for consistent indentation and positioning of modelVersion across modules
- remove duplicated dependency declarations and align shared properties such as the MySQL driver version to clean up Maven warnings

## Testing
- mvn -f thoth/pom.xml -q -DskipTests validate *(fails: cannot resolve org.springframework.boot:spring-boot-starter-parent because the network is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0670ce148326aa3241f26830a3da